### PR TITLE
Add gh workflows and drop support for Nodejs 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+name: chapi-playground-test-suite CI
+
+on:
+  push:
+    branches:
+      - '*'
+  schedule:
+    # Schedule to run every day at 2 PM UTC timezone (10AM EST)
+    - cron: "0 14 * * *"
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run: npm install
+    - name: Run eslint
+      run: npm run lint
+
+  test-db-config:
+    timeout-minutes: 10
+    needs: [lint]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Set and Create Configuration File
+        env:
+          DB_CONFIG: ${{ secrets.DB_CONFIG }}
+        run: |
+          echo "$DB_CONFIG" > ./configs/digitalbazaar.cjs
+      - name: Install Dependencies
+        run: npm install
+      - name: Run Tests with Node.js ${{ matrix.node-version }}
+        run: npm test
+        continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ following specifications:
 
 ### Install
 
-This project requires Node.js v16.
+This project requires Node.js >= v18.
 
 The required dependencies to run the test suite locally can be installed as
 follows

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://digitalbazaar.com/"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "bugs": {
     "url": "https://github.com/credential-handler/chapi-issuer-test-suite/issues"


### PR DESCRIPTION
Addresses #4 

Notes: 

- Test and lint jobs will execute on a push event on any branch, as well as daily at 2 PM UTC (10 AM EST) according to the scheduled time.

- Some of the issuer tests were failing so I set the `continue-on-error` option to `true` so it continues to run without causing the entire workflow to fail. It can be removed once we have all tests passing for DB issuer. Opened issue here https://github.com/credential-handler/chapi-playground-test-suite/issues/6

~TODO:~

- [x] DB_CONFIG needs to be set